### PR TITLE
Adicionando a camada Middleware para proteção de rota

### DIFF
--- a/Backend/src/middleware/auth.middleware.js
+++ b/Backend/src/middleware/auth.middleware.js
@@ -1,0 +1,20 @@
+import { clerkClient } from "@clerk/express";
+
+export const protectRoute = async (req, res, next) => {
+    if(!req.auth.userId) {
+       return res.status(401).json({ message: "Unauthorized - you must be logged in " });
+    }
+    next();
+};
+
+export const requireAdmin = async (req, res, next) => {
+   try{
+    const currentUser = await clerkClient.users.getUser(req.auth.userId);
+    const isAdmin = process.env.ADMIN_EMAIL === currentUser.primaryEmailAddress.emailAddress;
+    if(!isAdmin) {
+      return res.status(403).json({ message: "Unauthorized  - you must be an admin " });
+    } next();  
+} catch(error) {
+return res.status(500).json({ message: "Internal server error", error });
+  }
+};

--- a/Backend/src/routes/admin.route.js
+++ b/Backend/src/routes/admin.route.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { getAdmin } from "../controller/admin.controller.js";
+import { protectRoute, requireAdmin } from "../middleware/auth.middleware.js";
 
 const router = Router();
 
-router.get("/", getAdmin);
+router.get("/", protectRoute, requireAdmin, createSong);
 
 export default router;

--- a/Backend/src/routes/user.route.js
+++ b/Backend/src/routes/user.route.js
@@ -3,6 +3,7 @@ import { Router } from "express";
 const router = Router();
 
 router.get("/", (req, res) => {
+  req.auth.userId
   res.send('User rout with GET method');
 });
 

--- a/Backend/src/server.js
+++ b/Backend/src/server.js
@@ -2,7 +2,7 @@ import express from 'express';
 import dotenv from 'dotenv';
 
 import { connectDB} from './lib/db.js'; 
-
+import { clerkMiddleware } from '@clerk/express'
 import userRoutes from './routes/user.route.js';
 import authRoutes from './routes/auth.route.js';
 import adminRoutes from './routes/admin.route.js';
@@ -17,6 +17,8 @@ const app = express();
 const PORT = process.env.PORT;
 
 app.use(express.json()); //to parse req.body
+
+app.use(clerkMiddleware()); // this will add auth to req obj => req.auth
 
 app.use("/api/users", userRoutes)
 app.use("/api/auth", authRoutes)


### PR DESCRIPTION
### Adicionadas a cama de proteção Middleware com as tratativas de rede HTTP.
Foram criados dois middlewares de autenticação para uma API Express usando Clerk:

**protectRoute**

Verifica se existe `[req.auth.userId]` (ou seja, se o usuário está autenticado).
Se não estiver, retorna erro 401 (não autorizado).
Se estiver, chama [next()](vscode-file://vscode-app/c:/Users/VICTOR/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) para continuar a requisição.

**requireAdmin**

Busca o usuário atual usando Clerk `[clerkClient.users.getUser]`.
Compara o e-mail principal do usuário com o e-mail de admin definido em `[process.env.ADMIN_EMAIL]`.
Se não for admin, retorna erro 403 (proibido).
Se for admin, chama `[next()]`.
Se ocorrer erro, retorna erro `500 (erro interno do servidor)`.

Esses middlewares servem para proteger rotas e garantir que apenas usuários autenticados e/ou administradores possam acessar determinadas partes da sua API.